### PR TITLE
Fix: Non-destructive replaceWith for imageReady (fixes #13)

### DIFF
--- a/js/adapt-graphicLottie.js
+++ b/js/adapt-graphicLottie.js
@@ -42,7 +42,15 @@ class GraphicLottie extends Backbone.Controller {
     const $img = $(img);
     const div = document.createElement('div');
     const $div = $(div);
-    $img.replaceWith($div);
+
+    // Do replaceWith using detach instead of remove to preserve
+    // imageready event listeners
+    const $parent = $img.parent();
+    const previousSibling = $img[0].previousSibling;
+    $img.detach();
+    if (!previousSibling) $parent.prepend($div);
+    else $div.insertAfter(previousSibling);
+
     const lottieView = div.lottieView = new LottieView({
       el: div,
       replacedEl: img


### PR DESCRIPTION
fixes #13 

### Fix
* `$img.replaceWith($div);` removes `load` event listeners attached by imageReady causing the notify loading to hang. Corrected with non-destructive replaceWith.

References:
* https://api.jquery.com/remove/
* https://api.jquery.com/replacewith/
* https://api.jquery.com/detach/