### PR TITLE
Fix: Adds support for Visua11y's 'no animations' option (fixes #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The attributes listed below are used in *course.json* to configure **Adapt Graph
 
 ----------------------------
 
-**Framework versions:**  >=5.14<br/>
+**Framework versions:**  >=5.31.27<br/>
 **Author / maintainer:** Kineo<br/>
 **Accessibility support:** Yes<br/>
 **RTL support:** Yes<br/>

--- a/js/LottieView.js
+++ b/js/LottieView.js
@@ -257,7 +257,6 @@ export default class LottieView extends Backbone.View {
 
   onClick() {
     if (!this.config._showPauseControl || this.isLoopsComplete) return;
-
     this.togglePlayPause();
     this.hasUserPaused = this.isPaused;
     if (this.hasUserPaused && this.config._onPauseRewind) this.rewind();

--- a/js/LottieView.js
+++ b/js/LottieView.js
@@ -202,6 +202,7 @@ export default class LottieView extends Backbone.View {
     this.showControls = false;
     this.hasUserPaused = true;
     this.pause();
+    this.undelegateEvents();
   }
 
   render() {

--- a/js/LottieView.js
+++ b/js/LottieView.js
@@ -63,8 +63,7 @@ export default class LottieView extends Backbone.View {
   }
 
   get isFinished() {
-    // If not looping, Lottie will stop one frame before the end and not complete the loop.
-    // Otherwise, Lottie will increase the play count by one.
+    // if not looping, Lottie will stop one frame before the end and not complete the loop or update counts accordingly
     return Boolean(this.animation?.currentFrame >= this.animation?.totalFrames - 1);
   }
 

--- a/js/LottieView.js
+++ b/js/LottieView.js
@@ -1,7 +1,7 @@
 import Adapt from 'core/js/adapt';
 import device from 'core/js/device';
 import Lottie from 'libraries/lottie.min';
-import documentModifications, { DOMElementModifications } from 'core/js/DOMElementModifications';
+import documentModifications from 'core/js/DOMElementModifications';
 import ReactDOM from 'react-dom';
 import React from 'react';
 import { templates } from 'core/js/reactHelpers';

--- a/js/LottieView.js
+++ b/js/LottieView.js
@@ -155,7 +155,7 @@ export default class LottieView extends Backbone.View {
   onOffScreen() {
     // disable animation if already playing and should only play on first inview
     if (this.hasStarted && this.config._playFirstViewOnly) {
-      this.goToEndAndStop();
+      this.stopAtEnd();
       return;
     }
     // if not looping, an animation will need to be rewound/stopped before it can be replayed
@@ -202,7 +202,7 @@ export default class LottieView extends Backbone.View {
     this.play();
   }
 
-  goToEndAndStop() {
+  stopAtEnd() {
     const config = Adapt.course.get('_graphicLottie');
     const lastFrame = this.animation.totalFrames - 1;
     this.animation.goToAndStop(lastFrame, true);
@@ -285,7 +285,7 @@ export default class LottieView extends Backbone.View {
 
     // Stop on last frame
     this.isPausedWithVisua11y = true;
-    this.goToEndAndStop();
+    this.stopAtEnd();
   }
 
   destroyAnimation() {

--- a/js/LottieView.js
+++ b/js/LottieView.js
@@ -196,13 +196,13 @@ export default class LottieView extends Backbone.View {
   }
 
   goToEndAndStop() {
+    const config = Adapt.course.get('_graphicLottie');
     const lastFrame = this.animation.totalFrames - 1;
     this.animation.loop = 0;
     this.animation.goToAndStop(lastFrame, true);
-    this.showControls = false;
+    config._showPauseControl = false;
     this.hasUserPaused = true;
     this.pause();
-    this.undelegateEvents();
   }
 
   render() {

--- a/js/LottieView.js
+++ b/js/LottieView.js
@@ -15,7 +15,7 @@ export default class LottieView extends Backbone.View {
   }
 
   initialize({ replacedEl }) {
-    _.bindAll(this, 'render', 'onScreenChange', 'onDataReady', 'checkVisua11y');
+    _.bindAll(this, 'render', 'onScreenChange', 'onDataReady');
     this.replacedEl = replacedEl;
     this.syncAttributes();
     const fileExtension = this.config._fileExtension || 'svgz';
@@ -140,7 +140,7 @@ export default class LottieView extends Backbone.View {
   setUpListeners() {
     this.$el.on('onscreen', this.onScreenChange);
     this.listenTo(Adapt, 'device:resize', this.render);
-    documentModifications.on('changed:html', this.checkVisua11y);
+    this.listenTo(documentModifications, 'changed:html', this.checkVisua11y);
   }
 
   onScreenChange(event, { onscreen, percentInview } = {}) {

--- a/js/LottieView.js
+++ b/js/LottieView.js
@@ -15,7 +15,7 @@ export default class LottieView extends Backbone.View {
   }
 
   initialize({ replacedEl }) {
-    _.bindAll(this, 'render', 'onScreenChange', 'onDataReady');
+    _.bindAll(this, 'render', 'onScreenChange', 'onDataReady', 'checkVisua11y');
     this.replacedEl = replacedEl;
     this.syncAttributes();
     const fileExtension = this.config._fileExtension || 'svgz';
@@ -63,7 +63,8 @@ export default class LottieView extends Backbone.View {
   }
 
   get isFinished() {
-    // if not looping, Lottie will stop one frame before the end and not complete the loop or update counts accordingly
+    // If not looping, Lottie will stop one frame before the end and not complete the loop.
+    // Otherwise, Lottie will increase the play count by one.
     return Boolean(this.animation?.currentFrame >= this.animation?.totalFrames - 1);
   }
 
@@ -140,7 +141,6 @@ export default class LottieView extends Backbone.View {
   setUpListeners() {
     this.$el.on('onscreen', this.onScreenChange);
     this.listenTo(Adapt, 'device:resize', this.render);
-    this.checkVisua11y = this.checkVisua11y.bind(this);
     documentModifications.on('changed:html', this.checkVisua11y);
   }
 
@@ -256,6 +256,7 @@ export default class LottieView extends Backbone.View {
 
   onClick() {
     if (!this.config._showPauseControl || this.isLoopsComplete) return;
+
     this.togglePlayPause();
     this.hasUserPaused = this.isPaused;
     if (this.hasUserPaused && this.config._onPauseRewind) this.rewind();
@@ -263,8 +264,8 @@ export default class LottieView extends Backbone.View {
 
   checkVisua11y() {
     const htmlClasses = document.documentElement.classList;
-
     if (!htmlClasses.contains('a11y-no-animations')) return;
+
     // Stop on last frame
     this.goToEndAndStop();
   }

--- a/js/LottieView.js
+++ b/js/LottieView.js
@@ -196,7 +196,9 @@ export default class LottieView extends Backbone.View {
     this.render();
   }
 
-  replay() {
+  restart() {
+    const config = Adapt.course.get('_graphicLottie');
+    config._showPauseControl = this._originalShowPauseControl;
     this.hasUserPaused = false;
     this.rewind();
     this.play();
@@ -276,10 +278,8 @@ export default class LottieView extends Backbone.View {
 
     // Check if animation should start playing again
     if (this.isPausedWithVisua11y && !shouldStopAnimations) {
-      const config = Adapt.course.get('_graphicLottie');
-      config._showPauseControl = this._originalShowPauseControl;
       this.isPausedWithVisua11y = false;
-      this.replay();
+      this.restart();
       return;
     }
 

--- a/js/LottieView.js
+++ b/js/LottieView.js
@@ -200,6 +200,7 @@ export default class LottieView extends Backbone.View {
     this.animation.loop = 0;
     this.animation.goToAndStop(lastFrame, true);
     this.showControls = false;
+    this.hasUserPaused = true;
     this.pause();
   }
 

--- a/js/LottieView.js
+++ b/js/LottieView.js
@@ -196,6 +196,12 @@ export default class LottieView extends Backbone.View {
     this.render();
   }
 
+  replay() {
+    this.hasUserPaused = false;
+    this.rewind();
+    this.play();
+  }
+
   goToEndAndStop() {
     const config = Adapt.course.get('_graphicLottie');
     const lastFrame = this.animation.totalFrames - 1;
@@ -203,14 +209,6 @@ export default class LottieView extends Backbone.View {
     config._showPauseControl = false;
     this.hasUserPaused = true;
     this.pause();
-  }
-
-  replay() {
-    const config = Adapt.course.get('_graphicLottie');
-    config._showPauseControl = this.originalConfig._showPauseControl;
-    this.hasUserPaused = false;
-    this.rewind();
-    this.play();
   }
 
   render() {
@@ -278,6 +276,8 @@ export default class LottieView extends Backbone.View {
 
     // Check if animation should start playing again
     if (this.isPausedWithVisua11y && !shouldStopAnimations) {
+      const config = Adapt.course.get('_graphicLottie');
+      config._showPauseControl = this.originalConfig._showPauseControl;
       this.isPausedWithVisua11y = false;
       this.replay();
       return;

--- a/js/LottieView.js
+++ b/js/LottieView.js
@@ -140,10 +140,8 @@ export default class LottieView extends Backbone.View {
   setUpListeners() {
     this.$el.on('onscreen', this.onScreenChange);
     this.listenTo(Adapt, 'device:resize', this.render);
-
-    documentModifications.on('changed:html', event => {
-      this.checkVisua11y();
-    });
+    this.checkVisua11y = this.checkVisua11y.bind(this);
+    documentModifications.on('changed:html', this.checkVisua11y);
   }
 
   onScreenChange(event, { onscreen, percentInview } = {}) {

--- a/js/LottieView.js
+++ b/js/LottieView.js
@@ -16,7 +16,7 @@ export default class LottieView extends Backbone.View {
 
   initialize({ replacedEl }) {
     _.bindAll(this, 'render', 'onScreenChange', 'onDataReady');
-    this.originalConfig = { ...Adapt.course.get('_graphicLottie') };
+    this._originalShowPauseControl = Adapt.course.get('_graphicLottie')._showPauseControl;
     this.replacedEl = replacedEl;
     this.isPausedWithVisua11y = false;
     const fileExtension = this.config._fileExtension || 'svgz';
@@ -277,7 +277,7 @@ export default class LottieView extends Backbone.View {
     // Check if animation should start playing again
     if (this.isPausedWithVisua11y && !shouldStopAnimations) {
       const config = Adapt.course.get('_graphicLottie');
-      config._showPauseControl = this.originalConfig._showPauseControl;
+      config._showPauseControl = this._originalShowPauseControl;
       this.isPausedWithVisua11y = false;
       this.replay();
       return;

--- a/js/LottieView.js
+++ b/js/LottieView.js
@@ -264,10 +264,9 @@ export default class LottieView extends Backbone.View {
   checkVisua11y() {
     const htmlClasses = document.documentElement.classList;
 
-    if (htmlClasses.contains('a11y-no-animations')) {
-      // Stop on last frame
-      this.goToEndAndStop();
-    }
+    if (!htmlClasses.contains('a11y-no-animations')) return;
+    // Stop on last frame
+    this.goToEndAndStop();
   }
 
   destroyAnimation() {

--- a/js/adapt-graphicLottie.js
+++ b/js/adapt-graphicLottie.js
@@ -6,6 +6,7 @@ import documentModifications from 'core/js/DOMElementModifications';
 class GraphicLottie extends Backbone.Controller {
 
   initialize() {
+    _.bindAll(this, 'checkOnScreen');
     this.listenTo(Adapt, 'app:dataReady', this.onDataReady);
     this.waitingFor = 0;
   }
@@ -18,7 +19,7 @@ class GraphicLottie extends Backbone.Controller {
   }
 
   setUpEventListeners() {
-    document.body.addEventListener('transitionend', this.checkOnScreen.bind(this));
+    document.body.addEventListener('transitionend', this.checkOnScreen);
     this.listenTo(Adapt, 'notify:opened', this.checkOnScreen);
   }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-graphicLottie",
   "version": "2.0.4",
-  "framework": ">=5.14",
+  "framework": ">=5.31.27",
   "homepage": "https://github.com/cgkineo/adapt-graphicLottie",
   "issues": "https://github.com/cgkineo/adapt-graphicLottie/issues",
   "extension": "graphicLottie",


### PR DESCRIPTION
Fixes #3 

### Fix
* Adds support for Visua11y's "no animations" option. Requires framework **v5.31.27** due to the DOM Element Modification API dependency
* Fixes issue when using `"_playFirstViewOnly": true` and scrolling off and back again. The frame displayed when back on screen was blank. May not be an issue (see notes).

### Notes
For some reason, I needed to subtract one from the total frames in order to go to the last frame.

```
this.animation.totalFrames - 1
```

This was causing an issue with `_playFirstViewOnly` which has been fixed. It would be good to know if the problem was with the specific `.svgz` [file](https://lottiefiles.com/animations/cube-shape-animation-k69Xropjds) that I was using, or if others can reproduce the same issue.

In any case, would it be safer to just stop at the 2nd to last frame in case any given `.svgz` file has the same issue? I don't know how often this issue comes up.