### PR TITLE
Update: Convert html selectors to CSS .html selectors (fixes #25)

### DIFF
--- a/less/graphicLottie.less
+++ b/less/graphicLottie.less
@@ -42,8 +42,8 @@
     opacity: 0;
   }
 
-  html:not(.touch) .is-playing:hover &__controls,
-  html:not(.touch) .is-playing:focus-within &__controls {
+  .html:not(.touch) .is-playing:hover &__controls,
+  .html:not(.touch) .is-playing:focus-within &__controls {
     opacity: 1;
   }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-graphicLottie",
   "version": "2.0.5",
-  "framework": ">=5.31.27",
+  "framework": ">=5.46.4",
   "homepage": "https://github.com/cgkineo/adapt-graphicLottie",
   "issues": "https://github.com/cgkineo/adapt-graphicLottie/issues",
   "extension": "graphicLottie",


### PR DESCRIPTION
Fix #25 

### Update
* Convert `html` selectors to CSS `.html` selectors in Less

### Requires
Needs FW version bump:
* https://github.com/adaptlearning/adapt-contrib-core/pull/654
* https://github.com/adaptlearning/adapt_framework/pull/3681