### PR TITLE
Fix: Add image role for aria-label to read with JAWS (fixes #28)

### DIFF
--- a/js/LottieView.js
+++ b/js/LottieView.js
@@ -134,7 +134,8 @@ export default class LottieView extends Backbone.View {
           if (name === 'class') return attrs;
           return { ...{ [name]: value }, ...attrs };
         }, {}),
-        id: img.id
+        id: img.id,
+        role: 'image'
       })
       .addClass($(img).attr('class'));
   }


### PR DESCRIPTION
Fixes https://github.com/cgkineo/adapt-graphicLottie/issues/28

### Fix
Without a semantic element or ARIA `role`, the `aria-label` won't read. NVDA and voiceover seem less fussy.

Applying `role="image"` to the animation container `<div>`, the asset is now identified as an image/graphic as well as reading the alt text.

### Testing
1. Set `_graphic.alt` text for animation.
2. With JAWS running, navigate to the animation. Animations with alt text provided should be included in the keyboard order and the alt text read.


