### PR TITLE
Fix: Remove deprecated inview call (fix #30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,7 @@ The attributes listed below are used in *course.json* to configure **Adapt Graph
 
 ----------------------------
 
-**Framework versions:**  >=5.31.27<br/>
 **Author / maintainer:** Kineo<br/>
 **Accessibility support:** Yes<br/>
 **RTL support:** Yes<br/>
-**Cross-platform coverage:** Evergreen + IE11<br/>
+**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge, Safari for macOS/iOS/iPadOS, Opera <br>

--- a/js/adapt-graphicLottie.js
+++ b/js/adapt-graphicLottie.js
@@ -24,7 +24,7 @@ class GraphicLottie extends Backbone.Controller {
   }
 
   checkOnScreen() {
-    $.inview();
+    $(window).trigger('resize');
   }
 
   setUp() {

--- a/js/adapt-graphicLottie.js
+++ b/js/adapt-graphicLottie.js
@@ -6,25 +6,8 @@ import documentModifications from 'core/js/DOMElementModifications';
 class GraphicLottie extends Backbone.Controller {
 
   initialize() {
-    _.bindAll(this, 'checkOnScreen');
-    this.listenTo(Adapt, 'app:dataReady', this.onDataReady);
+    this.listenTo(Adapt, 'app:dataReady', this.setUp);
     this.waitingFor = 0;
-  }
-
-  onDataReady() {
-    const config = Adapt.course.get('_graphicLottie');
-    if (!config?._isEnabled) return;
-    this.setUpEventListeners();
-    this.setUp();
-  }
-
-  setUpEventListeners() {
-    document.body.addEventListener('transitionend', this.checkOnScreen);
-    this.listenTo(Adapt, 'notify:opened', this.checkOnScreen);
-  }
-
-  checkOnScreen() {
-    $(window).trigger('resize');
   }
 
   setUp() {


### PR DESCRIPTION
Fix #30 

### Fix
* Remove deprecated `$.inview()` call and related functions

### Note
In Core, the deprecated message comes from the inview.js library and this [PR](https://github.com/adaptlearning/adapt-contrib-core/pull/579):

```
  // force an inview check - standard trigger event jquery api behaviour
  $.inview = $.onscreen = function() {
    console.log('calling $.inview or $.onscreen directly is deprecate');
  };
```
 Created this [issue](https://github.com/adaptlearning/adapt-contrib-core/issues/709) to improve the deprecated message.