### PR TITLE
Fix: Add call to checkVisua11y when onDataReady (fixes #32)

### DIFF
--- a/js/LottieView.js
+++ b/js/LottieView.js
@@ -263,6 +263,7 @@ export default class LottieView extends Backbone.View {
     this.rewind();
     this.trigger('ready');
     this.onScreenChange(null, this.$el.onscreen());
+    this.checkVisua11y();
   }
 
   onClick() {


### PR DESCRIPTION
### Fix
* Animations added following content becoming untrickled, won't always account for visua11y settings as the animation hasn't been created before the check and potentially further DOM modifications.

Fixes https://github.com/cgkineo/adapt-graphicLottie/issues/32




